### PR TITLE
from map has extra opening bracket

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1181,7 +1181,7 @@ class DataClassGenerator {
                 // List<E>
                 if (p.isCollection) {
                     const defaultValue = withDefaultValues ? ' ?? <int>[]' : '';
-                    method += `${p.type}.from((${leftOfValue}${value}${defaultValue}${rightOfValue} as List<int>).map<${p.listType.rawType}>((x) => ${p.listType.rawType}.values[x]),)`
+                    method += `${p.type}.from(${leftOfValue}${value}${defaultValue}${rightOfValue} as List<int>).map<${p.listType.rawType}>((x) => ${p.listType.rawType}.values[x]),)`
                 } else {
                     const defaultValue = withDefaultValues ? ' ?? 0' : '';
                     method += `${p.rawType}.values[${leftOfValue}${value}${defaultValue}${rightOfValue} as int]`;


### PR DESCRIPTION
How to reproduce the error?

Please generate the model for this class

```dart
class User {
  String name;
  List<String> children;
}
```

The generated model will look something like this. In `User.fromMap` we have invalid code `List<String>.from((map['children'] as List<String>)`

There is one extra opening parentheses

```dart

import 'dart:convert';

class User {
  String name;
  List<String> children;
  User({
    required this.name,
    required this.children,
  });

  Map<String, dynamic> toMap() {
    return <String, dynamic>{
      'name': name,
      'children': children,
    };
  }

  factory User.fromMap(Map<String, dynamic> map) {
    return User(
      name: map['name'] as String,
      children: List<String>.from((map['children'] as List<String>),
    );
  }

  String toJson() => json.encode(toMap());

  factory User.fromJson(String source) => User.fromMap(json.decode(source) as Map<String, dynamic>);
}
```